### PR TITLE
drivers: ezi2c: Fix typo leading to assert

### DIFF
--- a/drivers/source/cy_scb_ezi2c.c
+++ b/drivers/source/cy_scb_ezi2c.c
@@ -917,7 +917,7 @@ static void HandleAddress(CySCB_Type *base, cy_stc_scb_ezi2c_context_t *context)
             cmd = SCB_I2C_S_CMD_S_NACK_Msk;
 
             /* Disable the stop interrupt source */
-            Cy_SCB_SetI2CInterruptMask(base, CY_SCB_EZI2C_SLAVE_INTR_NO_STOP);
+            Cy_SCB_SetSlaveInterruptMask(base, CY_SCB_EZI2C_SLAVE_INTR_NO_STOP);
         }
     }
 


### PR DESCRIPTION
When receiving an I2C address that doesn't match address1 or address2, call the correct interrupt clearing function. Passing CY_SCB_EZI2C_SLAVE_INTR_NO_STOP to Cy_SCB_SetI2CInterruptMask leads to an assert

By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Provide the information we need to review your PR. What problem does the pull request solve? "Bug fix" is not a good description.
Typo in EZI2C bad address handling

Related Issue
If you opened an issue before creating the PR, point to it here.
https://github.com/Infineon/psoc6pdl/issues/2

Context
What do we need to know about your development environment, tools, target, and so on. Screenshots are always helpful if there is a UI element to this PR.